### PR TITLE
Make quereis to share the same server by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
                 },
                 "bazel.queriesShareServer": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Use the same Bazel server for queries and builds. By default, vscode-bazel uses a separate server for queries so that they can be executed in parallel with builds. You can enable this setting if running multiple Bazel servers has a negative performance impact on your system, but you may experience degraded performance in Visual Studio Code for operations that require queries."
                 },
                 "bazel.enableCodeLens": {


### PR DESCRIPTION
The bazel query used to introspect the targets available assumes that the generated files are
already there.
This creates the problem that you have to first generate the files once.
https://github.com/bazelbuild/vscode-bazel/issues/265

Not sharing the same server makes it harder because the output is a random one.
This means that for a normal user, it will be hard to make it work when query does not
use the same server like your normal bazel queries.
Because of that, it is better to have the queriesShareServer to true by default
and the expert users can set it to false if they want.